### PR TITLE
Make ReadAsync async

### DIFF
--- a/WebService.Entities/Material.cs
+++ b/WebService.Entities/Material.cs
@@ -64,8 +64,4 @@ public class Material
     public ICollection<Author> Authors { get; set; }
     public DateTime TimeStamp { get; set; }
 
-    public bool hasMinimumAverageRating(int minimumRating)
-        => Ratings.Count() == 0 ? true : Ratings.Average(r => r.Value) >= minimumRating;
-
-
 }

--- a/WebService.Infrastructure/MaterialRepository.cs
+++ b/WebService.Infrastructure/MaterialRepository.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace WebService.Infrastructure
 {
@@ -132,15 +131,20 @@ namespace WebService.Infrastructure
 
         public async Task<(Status, IReadOnlyCollection<MaterialDTO>)> ReadAsync(SearchForm searchInput)
         {
-            var materials = _context.Materials.AsEnumerable()
-                                              .Where(material => material.hasMinimumAverageRating(searchInput.Rating))
-                                              .Where(MayContainProgrammingLanguage(searchInput))
-                                              .Where(MayContainLanguage(searchInput))
-                                              .Where(MayContainMedia(searchInput))
-                                              .Where(MayContainTag(searchInput))
-                                              .Where(MayContainLevel(searchInput))
-                                              .Select(ConvertMaterialToMaterialDTO)
-                                              .ToList();
+            // We can't have the server translate our query where we do linq statements on searchInput :(
+            var materialsWhereRatingHolds = await _context.Materials
+                .Where(material => material.Ratings.Average(rating => rating.Value) >= searchInput.Rating)
+                .ToListAsync();
+
+            // We're doing the following computations on the client, instead of the server
+            var materials = materialsWhereRatingHolds
+                .Where(material => MayContainProgrammingLanguage(searchInput).Invoke(material))
+                .Where(material => MayContainLanguage(searchInput).Invoke(material))
+                .Where(material => MayContainMedia(searchInput).Invoke(material))
+                .Where(material => MayContainTag(searchInput).Invoke(material))
+                .Where(material => MayContainLevel(searchInput).Invoke(material))
+                .Select(ConvertMaterialToMaterialDTO)
+                .ToList();
 
             if (materials.Count() == 0)
             {


### PR DESCRIPTION
An oversight from my previous PR was that `ReadAsync(SearchForm)` in `MaterialRepository` was not async. 

It was a challenge to implement, due to LINQ not being able to translate queries where we do other LINQ statements on objects that is not contained within the database (SearchForm).

The method now gets all materials from the server where the minimum average rating holds, and then applies the filters on the data, when it is transfered to the client (our server).