### PR TITLE
Enable concurrent workflows on a per branch basis

### DIFF
--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -3,7 +3,7 @@ name: .NET
 on: push
 
 concurrency: 
-  group: concurrency-group-${{ github.ref }}
+  group: concurrency-group-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -3,7 +3,7 @@ name: .NET
 on: push
 
 concurrency: 
-  group: concurrency-group-${GITHUB_REF##*/}
+  group: concurrency-group-${{GITHUB_REF##*/}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -6,12 +6,6 @@ concurrency:
   group: concurrency-group-${{ github.ref }}
   cancel-in-progress: true
 
-
-
-
-
-
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,6 +22,3 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Sleep
-      run: |
-        sleep 300

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -22,3 +22,6 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: Sleep
+      run: |
+        sleep 300

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -3,7 +3,7 @@ name: .NET
 on: push
 
 concurrency: 
-  group: main-concurrency-group
+  group: concurrency-group-${GITHUB_REF##*/}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -6,6 +6,12 @@ concurrency:
   group: concurrency-group-${{ github.ref }}
   cancel-in-progress: true
 
+
+
+
+
+
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests_on_push.yml
+++ b/.github/workflows/unit_tests_on_push.yml
@@ -3,7 +3,7 @@ name: .NET
 on: push
 
 concurrency: 
-  group: concurrency-group-${{GITHUB_REF##*/}}
+  group: concurrency-group-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
* Enabled concurrent workflows to run, one per branch at the time. This prevents the previous behaviour of only being able to have one workflow running at all times.

![billede](https://user-images.githubusercontent.com/490649/145278251-95b449bb-d427-4274-bd85-f604fefc0e2e.png)

Fixes #69 
